### PR TITLE
add `rust-toolchain.toml` to preserve rustc prefs.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
gm,

rocket requires a nightly build of rustc. i didnt want to have to `rustup default nightly` so i just added `rust-toolchain.toml` to preserve my `rustup` prefs.

best,
D.